### PR TITLE
#71: Remapped screen gpios to match design and removed splash screen

### DIFF
--- a/boardsupport/bsp/rootfs_overlay/etc/init.d/S02screen.sh
+++ b/boardsupport/bsp/rootfs_overlay/etc/init.d/S02screen.sh
@@ -5,10 +5,9 @@ export FRAMEBUFFER=/dev/fb1
 start()
 {
     # Load required modules
-    modprobe fbtft_device name=adafruit18 rotate=90
+    # Rotation ended up being 270 instead of 90 due a layout error
+    modprobe fbtft_device name=adafruit18 rotate=270 gpios=reset:24,dc:7
     modprobe fb_st7735r
-    # Load splash screen
-    fbv -d 1 /boot/splash.bmp &
 }
 
 case "$1" in


### PR DESCRIPTION
Fixes issue #71 

## List of Changes

 - Fixes GPIO mapping so display works correctly on PCB
 - Removes splashscreen since it's not typically visible
